### PR TITLE
Removed deprecation warnings surrounding 'named_scope'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -115,6 +115,37 @@ Write method:
   user.write_preference(:hot_salsa, false)      # => false
   user.write_preference(:language, "English")   # => "English"
 
+=== Accessible preferences
+
+If you want a preference to be accessible via the `attributes` or `attributes=` method on the
+model, use the `accessible_preference` method:
+
+  class User < ActiveRecord::Base
+    accessible_preference :hot_salsa
+    accessible_preference :two_percent_milk
+  end
+
+Now, you can easily update all the preferences at once from your controllers:
+
+In the view:
+
+  - form_for @user do |f|
+    = f.check_box :prefers_hot_salsa
+    = f.check_box :prefers_two_percent_milk
+
+In the controller:
+
+  UsersController < ApplicationController
+    def update
+      @user = User.find(params[:id])
+      @user.attributes = params[:user]
+
+      flash.notice = 'Saved preferences' if @user.save
+
+      render 'edit'
+    end
+  end
+
 === Accessing all preferences
 
 To get the collection of all custom, stored preferences for a particular record,

--- a/README.rdoc
+++ b/README.rdoc
@@ -117,8 +117,8 @@ Write method:
 
 === Accessible preferences
 
-If you want a preference to be accessible via the `attributes` or `attributes=` method on the
-model, use the `accessible_preference` method:
+If you want a preference to be accessible via the +attributes+ or +attributes=+ method on the
+model, use the +accessible_preference+ method:
 
   class User < ActiveRecord::Base
     accessible_preference :hot_salsa

--- a/README.rdoc
+++ b/README.rdoc
@@ -117,7 +117,7 @@ Write method:
 
 === Accessible preferences
 
-If you want a preference to be accessible via the +attributes+ or +attributes=+ method on the
+If you want a preference to be accessible via the +attributes+ method on the
 model, use the +accessible_preference+ method:
 
   class User < ActiveRecord::Base

--- a/lib/preferences.rb
+++ b/lib/preferences.rb
@@ -160,8 +160,8 @@ module Preferences
         after_save :update_preferences
         
         # Named scopes
-        named_scope :with_preferences, lambda {|preferences| build_preference_scope(preferences)}
-        named_scope :without_preferences, lambda {|preferences| build_preference_scope(preferences, true)}
+        scope :with_preferences, lambda {|preferences| build_preference_scope(preferences)}
+        scope :without_preferences, lambda {|preferences| build_preference_scope(preferences, true)}
         
         extend Preferences::ClassMethods
         include Preferences::InstanceMethods

--- a/lib/preferences.rb
+++ b/lib/preferences.rb
@@ -163,7 +163,7 @@ module Preferences
         # Named scopes
         scope :with_preferences, lambda {|preferences| build_preference_scope(preferences)}
         scope :without_preferences, lambda {|preferences| build_preference_scope(preferences, true)}
-        
+
         extend Preferences::ClassMethods
         include Preferences::InstanceMethods
       end
@@ -172,6 +172,8 @@ module Preferences
       name = name.to_s
       definition = PreferenceDefinition.new(name, *args)
       self.preference_definitions[name] = definition
+
+      attr_accessible :"prefers_#{name}" if definition.accessible?
       
       # Create short-hand accessor methods, making sure that the name
       # is method-safe in terms of what characters are allowed
@@ -223,8 +225,26 @@ module Preferences
       
       definition
     end
+
+    # Defines a preference that is accessible via the <tt>attributes</tt> method. This
+    # works by calling <tt>attr_accessible</tt> for the preference.
+    #
+    # Example:
+    #
+    #   class User < ActiveRecord::Base
+    #     accessible_preference :notifications
+    #   end
+    #
+    # This will add <tt>attr_accessible :prefers_notifications</tt> to the
+    # User model.
+    #
+    def accessible_preference(name, *args)
+      options = args.extract_options!.dup
+      options.merge!({ :accessible => true })
+      preference name, *(args << options)
+    end
   end
-  
+
   module ClassMethods #:nodoc:
     # Generates the scope for looking under records with a specific set of
     # preferences associated with them.

--- a/lib/preferences.rb
+++ b/lib/preferences.rb
@@ -1,4 +1,5 @@
 require 'preferences/preference_definition'
+require 'app/models/preference'
 
 # Adds support for defining preferences on ActiveRecord models.
 # 

--- a/lib/preferences/preference_definition.rb
+++ b/lib/preferences/preference_definition.rb
@@ -2,10 +2,14 @@ module Preferences
   # Represents the definition of a preference for a particular model
   class PreferenceDefinition
     # The data type for the content stored in this preference type
-    attr_reader :type
+    attr_reader :type, :accessible
+    alias :accessible? :accessible
     
     def initialize(name, *args) #:nodoc:
       options = args.extract_options!
+
+      @accessible = !!options.delete(:accessible)
+        
       options.assert_valid_keys(:default, :group_defaults)
       
       @type = args.first ? args.first.to_sym : :boolean

--- a/preferences.gemspec
+++ b/preferences.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = %q{aaron@pluginaweek.org}
   s.files = ["app/models", "app/models/preference.rb", "generators/preferences", "generators/preferences/USAGE", "generators/preferences/preferences_generator.rb", "generators/preferences/templates", "generators/preferences/templates/001_create_preferences.rb", "lib/preferences", "lib/preferences/preference_definition.rb", "lib/preferences.rb", "test/unit", "test/unit/preference_test.rb", "test/unit/preference_definition_test.rb", "test/app_root", "test/app_root/db", "test/app_root/db/migrate", "test/app_root/db/migrate/003_create_employees.rb", "test/app_root/db/migrate/004_migrate_preferences_to_version_1.rb", "test/app_root/db/migrate/002_create_cars.rb", "test/app_root/db/migrate/001_create_users.rb", "test/app_root/app", "test/app_root/app/models", "test/app_root/app/models/car.rb", "test/app_root/app/models/employee.rb", "test/app_root/app/models/user.rb", "test/app_root/app/models/manager.rb", "test/test_helper.rb", "test/factory.rb", "test/functional", "test/functional/preferences_test.rb", "CHANGELOG.rdoc", "init.rb", "LICENSE", "Rakefile", "README.rdoc"]
   s.homepage = %q{http://www.pluginaweek.org}
-  s.require_paths = ["lib"]
+  s.require_paths = ["lib", "."]
   s.rubyforge_project = %q{pluginaweek}
   s.rubygems_version = %q{1.3.5}
   s.summary = %q{Adds support for easily creating custom preferences for ActiveRecord models}


### PR DESCRIPTION
I changed the calls to the Rails 3 deprecated method `named_scope` in favor of `scope`.  I tried running the tests but I'm getting the following error:

```
rake test RAILS_FRAMEWORK_ROOT=/Users/cboyd/.rvm/gems/ruby-1.9.2-p0:/Users/cboyd/.rvm/gems/ruby-1.9.2-p136/gems/rails-3.0.3
(in /Users/cboyd/workspace/preferences)
/Users/cboyd/.rvm/rubies/ruby-1.9.2-p0/bin/ruby -I"lib:lib" "/Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "test/functional/preferences_test.rb" "test/unit/preference_definition_test.rb" "test/unit/preference_test.rb" 
/Users/cboyd/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/site_ruby/1.9.1/rubygems.rb:274:in `activate': can't activate rails (= 2.3.8, runtime) for [], already activated rails-3.0.3 for [] (Gem::LoadError)
    from /Users/cboyd/.rvm/rubies/ruby-1.9.2-p0/lib/ruby/site_ruby/1.9.1/rubygems.rb:216:in `try_activate'
    from <internal:lib/rubygems/custom_require>:32:in `rescue in require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/plugin_test_helper-0.3.1/generators/plugin_test_structure/templates/app_root/config/boot.rb:58:in `load_initializer'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/plugin_test_helper-0.3.1/generators/plugin_test_structure/templates/app_root/config/boot.rb:41:in `run'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/plugin_test_helper-0.3.1/generators/plugin_test_structure/templates/app_root/config/boot.rb:14:in `boot!'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/plugin_test_helper-0.3.1/generators/plugin_test_structure/templates/app_root/config/boot.rb:115:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/plugin_test_helper-0.3.1/lib/plugin_test_helper.rb:13:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:33:in `require'
    from <internal:lib/rubygems/custom_require>:33:in `rescue in require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /Users/cboyd/workspace/preferences/test/test_helper.rb:4:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from test/functional/preferences_test.rb:1:in `<top (required)>'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in `load'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in `block in <main>'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in `each'
    from /Users/cboyd/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in `<main>'
rake aborted!
Command failed with status (1): [/Users/cboyd/.rvm/rubies/ruby-1.9.2-p0/bin...]
```

Since this is just a simple method name change for a method that is already tested in the Rails source, I don't think there should be any failures from my changes.  If you would like to help me get the tests running that would be great too!
